### PR TITLE
fix: add missing docker configuration files

### DIFF
--- a/docker/laravel-scheduler
+++ b/docker/laravel-scheduler
@@ -1,0 +1,4 @@
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+* * * * * www-data cd /var/www/html && /usr/local/bin/php artisan schedule:run --no-interaction >> /proc/1/fd/1 2>&1

--- a/docker/nginx/dynamic-routes.conf
+++ b/docker/nginx/dynamic-routes.conf
@@ -1,0 +1,9 @@
+# Laravel + Livewire/Flux dynamic routes
+location ~ ^/livewire-[a-f0-9]+/ {
+    try_files $uri $uri/ /index.php?$query_string;
+}
+
+location ~* ^/flux/flux(\.min)?\.(js|css)$ {
+    expires off;
+    try_files $uri $uri/ /index.php?$query_string;
+}

--- a/docker/supervisor/app-services.conf
+++ b/docker/supervisor/app-services.conf
@@ -1,0 +1,12 @@
+[program:queue]
+command=php /var/www/html/artisan queue:work --tries=3 --timeout=60 --max-time=3600 --max-jobs=1000 --memory=128
+directory=/var/www/html
+autostart=true
+autorestart=true
+user=www-data
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stopwaitsecs=3600
+priority=40


### PR DESCRIPTION
## Summary
- Add missing `docker/laravel-scheduler` (cron job for Laravel scheduler)
- Add missing `docker/supervisor/app-services.conf` (queue worker config)
- Add missing `docker/nginx/dynamic-routes.conf` (Livewire/Flux route handling)

## Problem
Docker build failed with:
```
failed to calculate checksum of ref ... "/docker/laravel-scheduler": not found
```

The Dockerfile references these files but they were missing from the repository.

## Test plan
- [ ] Trigger Docker build workflow on this PR to verify the build succeeds