### PR TITLE
Trust reverse proxy headers

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -11,6 +12,13 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->trustProxies(at: '*', headers: Request::HEADER_X_FORWARDED_FOR |
+            Request::HEADER_X_FORWARDED_HOST |
+            Request::HEADER_X_FORWARDED_PORT |
+            Request::HEADER_X_FORWARDED_PROTO |
+            Request::HEADER_X_FORWARDED_AWS_ELB
+        );
+
         //
     })
     ->withExceptions(function (Exceptions $exceptions): void {


### PR DESCRIPTION
## Summary
- Add proxy trust configuration in `bootstrap/app.php`.
- Trust `X-Forwarded-*` and AWS ELB headers for reverse proxy support.

## Why
- Ensures request metadata (scheme, host, port, client IP) resolves correctly when behind a load balancer or proxy.

## Diff
- Import `Illuminate\Http\Request` in `bootstrap/app.php`.
- Configure trusted headers using `trustProxies(at: '*', headers: ...)`.
