### PR TITLE
Fix RAG chat send button gating

### DIFF
--- a/resources/views/livewire/rag-chat.blade.php
+++ b/resources/views/livewire/rag-chat.blade.php
@@ -81,7 +81,7 @@
     <div class="border-t border-neutral-200 dark:border-neutral-700 p-4">
         <form wire:submit.prevent="sendQuery" class="flex gap-3">
             <flux:input
-                wire:model.live.debounce.250ms="query"
+                wire:model.live="query"
                 placeholder="Ask a question about your documents..."
                 :disabled="$isProcessing"
                 class="flex-1"
@@ -89,7 +89,7 @@
             <flux:button
                 type="submit"
                 variant="primary"
-                :disabled="$isProcessing || blank(trim($query))"
+                :disabled="$isProcessing || $query === ''"
                 icon="paper-airplane"
             >
                 Send


### PR DESCRIPTION
## Summary
- Make RAG chat input/button reactivity deterministic by using  instead of debounced binding.
- Relax send button disable logic from  to explicit empty-string check so the button enables correctly.
- Keep backend fallback behavior untouched so chat still answers with generic guidance when no docs are available.

## Testing
- 
  !!!!!!

  Tests:    6 warnings (39 assertions)
  Duration: 0.51s,timeout:120000,