### PR TITLE
test: extend rag unit coverage

### DIFF
--- a/tests/Feature/DocumentIngestionPipelineTest.php
+++ b/tests/Feature/DocumentIngestionPipelineTest.php
@@ -15,6 +15,10 @@ use Livewire\Livewire;
 
 uses(RefreshDatabase::class);
 
+beforeEach(function (): void {
+    config()->set('app.key', 'base64:'.base64_encode(str_repeat('0', 32)));
+});
+
 test('upload request dispatches async ingestion job and returns quickly', function () {
     Queue::fake();
 
@@ -153,6 +157,62 @@ test('ingestion job marks document failed on final retry failure', function () {
         ->and($document->error_message)->toContain('Document ingestion failed after 1 attempt(s).')
         ->and($document->error_message)->toContain('Embedding API timeout')
         ->and(DocumentChunk::query()->count())->toBe(0);
+});
+
+test('ingestion job returns early when document is missing', function () {
+    $embeddingMock = Mockery::mock(EmbeddingService::class);
+    $chunkingMock = Mockery::mock(DocumentChunkingService::class);
+
+    $job = new ProcessDocumentIngestion(999999);
+    $job->handle($embeddingMock, $chunkingMock);
+
+    expect(Document::query()->count())->toBe(0)
+        ->and(DocumentChunk::query()->count())->toBe(0);
+});
+
+test('ingestion job retries when attempts remain', function () {
+    $user = User::factory()->create();
+
+    $document = Document::create([
+        'user_id' => $user->id,
+        'title' => 'Retry Doc',
+        'file_path' => 'documents/retry.txt',
+        'file_type' => 'txt',
+        'content' => 'content',
+        'excerpt' => 'excerpt',
+        'status' => 'pending',
+    ]);
+
+    $embeddingMock = Mockery::mock(EmbeddingService::class);
+    $embeddingMock->shouldReceive('generateEmbeddings')
+        ->once()
+        ->andThrow(new RuntimeException('Temporary upstream timeout'));
+
+    $chunkingMock = Mockery::mock(DocumentChunkingService::class);
+    $chunkingMock->shouldReceive('chunk')
+        ->once()
+        ->andReturn([
+            [
+                'chunk_index' => 0,
+                'content' => 'content',
+                'excerpt' => 'content',
+                'char_count' => 7,
+                'token_count' => 2,
+                'metadata' => ['chunk_size' => 1200, 'chunk_overlap' => 200],
+            ],
+        ]);
+
+    $job = new ProcessDocumentIngestion($document->id);
+    $job->tries = 2;
+
+    expect(fn () => $job->handle($embeddingMock, $chunkingMock))
+        ->toThrow(RuntimeException::class, 'Temporary upstream timeout');
+
+    $document->refresh();
+
+    expect($document->status)->toBe('processing')
+        ->and($document->error_message)->toBeNull()
+        ->and($document->completed_at)->toBeNull();
 });
 
 afterEach(function (): void {

--- a/tests/Unit/DocumentChunkingServiceTest.php
+++ b/tests/Unit/DocumentChunkingServiceTest.php
@@ -32,3 +32,42 @@ test('chunking service splits long text into multiple chunks', function () {
         ->and($chunks[0]['char_count'])->toBeGreaterThan(100)
         ->and($chunks[1]['token_count'])->toBeGreaterThan(10);
 });
+
+test('chunking service returns no chunks for blank text after normalization', function () {
+    config()->set('services.document.chunk_size', 1200);
+    config()->set('services.document.chunk_overlap', 200);
+
+    $service = new DocumentChunkingService;
+    $chunks = $service->chunk("  \n \t \n");
+
+    expect($chunks)->toBe([]);
+});
+
+test('chunking service clamps overlap to chunk size minus one', function () {
+    config()->set('services.document.chunk_size', 205);
+    config()->set('services.document.chunk_overlap', 999);
+
+    $service = new DocumentChunkingService;
+    $text = str_repeat('A', 230);
+    $chunks = $service->chunk($text);
+
+    expect($chunks)->toHaveCount(27)
+        ->and($chunks[0]['metadata']['chunk_overlap'])->toBe(204)
+        ->and($chunks[25]['content'])->toBe(str_repeat('A', 205))
+        ->and($chunks[26]['metadata']['chunk_size'])->toBe(205)
+        ->and($chunks[26]['chunk_index'])->toBe(26);
+});
+
+test('chunk metadata includes configured chunk size and overlap', function () {
+    config()->set('services.document.chunk_size', 205);
+    config()->set('services.document.chunk_overlap', 4);
+
+    $service = new DocumentChunkingService;
+    $chunks = $service->chunk(str_repeat('A', 430));
+
+    expect($chunks)->toHaveCount(3)
+        ->and($chunks[0]['metadata']['chunk_size'])->toBe(205)
+        ->and($chunks[0]['metadata']['chunk_overlap'])->toBe(4)
+        ->and($chunks[0]['chunk_index'])->toBe(0)
+        ->and($chunks[1]['chunk_index'])->toBe(1);
+});

--- a/tests/Unit/DocumentParserServiceTest.php
+++ b/tests/Unit/DocumentParserServiceTest.php
@@ -50,3 +50,58 @@ test('parser throws for unsupported file extension', function () {
     expect(fn () => app(DocumentParserService::class)->parse($file))
         ->toThrow(InvalidArgumentException::class, 'Unsupported file type: csv');
 });
+
+test('parser strips markdown images and links while keeping content', function () {
+    Storage::fake('local');
+    config()->set('services.document.disk', 'local');
+
+    $file = UploadedFile::fake()->createWithContent(
+        'notes.md',
+        "# Heading\n\n![hero image](image.png)\n\n[Guide](https://example.com) with **bold** text and more.\n"
+    );
+
+    $result = app(DocumentParserService::class)->parse($file);
+
+    expect($result['file_type'])->toBe('md')
+        ->and($result['content'])->not->toContain('![hero image]')
+        ->and($result['content'])->not->toContain('https://example.com')
+        ->and($result['content'])->not->toContain('**')
+        ->and($result['content'])->toContain('Guide')
+        ->and($result['content'])->toContain('bold text')
+        ->and($result['content'])->toStartWith('Heading');
+});
+
+test('parser parses pdf files through parser override for unit coverage', function () {
+    Storage::fake('local');
+    config()->set('services.document.disk', 'local');
+    config()->set('services.document.storage_path', 'documents-test');
+
+    $parser = new class extends DocumentParserService
+    {
+        protected function parsePdf(string $filePath): string
+        {
+            return $this->normalizeText('  PDF\nRaw   content  ');
+        }
+    };
+
+    $file = UploadedFile::fake()->createWithContent('specimen.pdf', 'fake binary');
+
+    $result = $parser->parse($file);
+
+    expect($result['file_type'])->toBe('pdf')
+        ->and($result['title'])->toBe('specimen')
+        ->and($result['content'])->toContain('PDF')
+        ->and($result['content'])->toContain('Raw content')
+        ->and($result['excerpt'])->toContain('PDF')
+        ->and($result['excerpt'])->toContain('Raw content')
+        ->and($result['file_path'])->toStartWith('documents-test/');
+});
+
+test('parser chunk helper splits long text with breakpoints', function () {
+    $parser = new DocumentParserService;
+    $chunks = $parser->chunk('Sentence one. Sentence two. Sentence three.', 12, 0);
+
+    expect($chunks)->toHaveCount(4)
+        ->and($chunks[0])->toBe('Sentence one')
+        ->and($chunks[3])->toBe(' three.');
+});

--- a/tests/Unit/EmbeddingServiceMathTest.php
+++ b/tests/Unit/EmbeddingServiceMathTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use App\Services\EmbeddingService;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+function configureEmbeddingServiceForTests(string $provider = 'openai'): void
+{
+    config()->set('services.embedding.provider', $provider);
+    config()->set('services.embedding.model', 'text-embedding-3-small');
+    config()->set('services.embedding.api_key', 'embedding-api-key');
+    config()->set('services.embedding.base_url', 'https://embed.example.com/v1');
+}
+
+test('generateEmbeddings returns empty array for empty input without sending HTTP', function () {
+    configureEmbeddingServiceForTests();
+    Http::fake();
+
+    $service = new EmbeddingService;
+
+    expect($service->generateEmbeddings([]))->toBe([]);
+
+    Http::assertNothingSent();
+});
+
+test('generateEmbeddings rejects payloads missing embedding data', function () {
+    configureEmbeddingServiceForTests();
+
+    Http::fake([
+        'https://embed.example.com/v1/embeddings' => Http::response(['oops' => 'missing data'], 200),
+    ]);
+
+    $service = new EmbeddingService;
+
+    expect(fn () => $service->generateEmbeddings(['hello']))
+        ->toThrow(RuntimeException::class, 'Embedding API response missing data[] payload.');
+});
+
+test('generateEmbeddings rejects non-array embedding items', function () {
+    configureEmbeddingServiceForTests();
+
+    Http::fake([
+        'https://embed.example.com/v1/embeddings' => Http::response([
+            'data' => [
+                ['embedding' => [0.1, 0.2, 0.3]],
+                ['embedding' => 'invalid'],
+            ],
+        ], 200),
+    ]);
+
+    $service = new EmbeddingService;
+
+    expect(fn () => $service->generateEmbeddings(['alpha', 'beta']))
+        ->toThrow(RuntimeException::class, 'Embedding API response contains an invalid embedding item.');
+});
+
+test('generateEmbeddings validates vector count matches input count', function () {
+    configureEmbeddingServiceForTests();
+
+    Http::fake([
+        'https://embed.example.com/v1/embeddings' => Http::response([
+            'data' => [
+                ['embedding' => [0.1, 0.2, 0.3]],
+            ],
+        ], 200),
+    ]);
+
+    $service = new EmbeddingService;
+
+    expect(fn () => $service->generateEmbeddings(['alpha', 'beta']))
+        ->toThrow(RuntimeException::class, 'Embedding API returned 1 vector(s) for 2 input(s).');
+});
+
+test('generateEmbedding returns first embedding from API response', function () {
+    configureEmbeddingServiceForTests();
+
+    Http::fake([
+        'https://embed.example.com/v1/embeddings' => Http::response([
+            'data' => [
+                ['embedding' => [1, 2, 3]],
+            ],
+        ], 200),
+    ]);
+
+    $service = new EmbeddingService;
+
+    expect($service->generateEmbedding('simple text'))->toBe([1.0, 2.0, 3.0]);
+});
+
+test('averageEmbeddings normalizes uneven vectors and empty vector lists', function () {
+    configureEmbeddingServiceForTests();
+
+    $service = new EmbeddingService;
+
+    expect($service->averageEmbeddings([[1, 2], [3]]))->toBe([2.0, 1.0])
+        ->and($service->averageEmbeddings([]))->toBe([]);
+});
+
+test('cosineSimilarity handles zero vectors as zero similarity', function () {
+    configureEmbeddingServiceForTests();
+
+    $service = new EmbeddingService;
+
+    expect($service->cosineSimilarity([0, 0, 0], [0.2, 0.4, 0.6]))->toBe(0.0)
+        ->and($service->cosineSimilarity([1, 0, 0], [0, 1, 0]))->toBe(0.0);
+});

--- a/tests/Unit/PgVectorPreflightServiceTest.php
+++ b/tests/Unit/PgVectorPreflightServiceTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Services\PgVectorPreflightService;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+test('preflight check is skipped when database driver is not PostgreSQL', function () {
+    $service = new class extends PgVectorPreflightService
+    {
+        protected function currentDriver(): string
+        {
+            return 'sqlite';
+        }
+
+        protected function vectorExtensionExists(): bool
+        {
+            throw new RuntimeException('vector extension lookup should be skipped for non-pgsql drivers');
+        }
+    };
+
+    $service->ensureVectorExtensionReady();
+
+    expect(true)->toBeTrue();
+});

--- a/tests/Unit/RagServiceHelperTest.php
+++ b/tests/Unit/RagServiceHelperTest.php
@@ -1,0 +1,173 @@
+<?php
+
+use App\Models\Document;
+use App\Models\DocumentChunk;
+use App\Services\EmbeddingService;
+use App\Services\RagService;
+use App\Services\VectorSearchService;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+function makeRagServiceForHelperTests(EmbeddingService $embeddingService, VectorSearchService $vectorSearchService): RagService
+{
+    config()->set('services.llm.provider', 'openai');
+    config()->set('services.llm.model', 'gpt-4o-mini');
+    config()->set('services.llm.base_url', 'https://api.openai.com/v1');
+    config()->set('services.llm.api_key', 'test-key');
+    config()->set('services.rag.max_chunks', 2);
+    config()->set('services.rag.max_context_chars', 80);
+    config()->set('services.rag.max_context_tokens', 120);
+    config()->set('services.rag.min_similarity', 0.5);
+    config()->set('services.rag.low_confidence_similarity', 0.7);
+
+    return new class($vectorSearchService, $embeddingService) extends RagService
+    {
+        protected Collection $queryDocuments;
+
+        public function __construct(VectorSearchService $vectorSearchService, EmbeddingService $embeddingService)
+        {
+            parent::__construct($vectorSearchService, $embeddingService);
+            $this->queryDocuments = collect();
+        }
+
+        public function buildUserPromptPublic(string $question, string $context, bool $isLowConfidence = false): string
+        {
+            return $this->buildUserPrompt($question, $context, $isLowConfidence);
+        }
+
+        public function fitChunkToBudgetPublic(mixed $chunk, int $remainingChars, int $remainingTokens): mixed
+        {
+            return $this->fitChunkToBudget($chunk, $remainingChars, $remainingTokens);
+        }
+
+        public function retrieveDocuments(string $query, int $limit = 5, ?int $userId = null, ?string $requestId = null): Collection
+        {
+            return $this->queryDocuments;
+        }
+    };
+}
+
+function makeChunkForRagService(
+    int $id,
+    int $documentId,
+    string $title,
+    string $content,
+    int $chunkIndex,
+    float $ragSimilarity
+): DocumentChunk {
+    $document = new Document([
+        'id' => $documentId,
+        'title' => $title,
+        'file_type' => 'md',
+    ]);
+
+    $chunk = new DocumentChunk([
+        'id' => $id,
+        'document_id' => $documentId,
+        'chunk_index' => $chunkIndex,
+        'content' => $content,
+        'excerpt' => mb_substr($content, 0, 80),
+        'embedding' => [0.1, 0.2, 0.3],
+        'char_count' => mb_strlen($content),
+        'token_count' => max(1, (int) ceil(mb_strlen($content) / 4)),
+        'metadata' => [],
+    ]);
+
+    $chunk->setRelation('document', $document);
+    $chunk->setAttribute('rag_similarity', $ragSimilarity);
+
+    return $chunk;
+}
+
+function setRagServiceDocuments(RagService $service, Collection $documents): void
+{
+    $reflection = new ReflectionClass($service);
+    $property = $reflection->getProperty('queryDocuments');
+
+    $property->setAccessible(true);
+    $property->setValue($service, $documents);
+}
+
+test('buildUserPrompt adds uncertainty instructions for low-confidence retrieval', function () {
+    $embeddingMock = Mockery::mock(EmbeddingService::class);
+    $vectorSearchMock = Mockery::mock(VectorSearchService::class);
+    $service = makeRagServiceForHelperTests($embeddingMock, $vectorSearchMock);
+
+    $lowConfidencePrompt = $service->buildUserPromptPublic('How do we deploy?', '[$S1] guide chunk', true);
+    $normalPrompt = $service->buildUserPromptPublic('How do we deploy?', '[$S1] guide chunk', false);
+
+    expect($lowConfidencePrompt)->toContain('low confidence')
+        ->and($normalPrompt)->not->toContain('low confidence');
+});
+
+test('fitChunkToBudget truncates long chunks and marks them as truncated', function () {
+    $embeddingMock = Mockery::mock(EmbeddingService::class);
+    $vectorSearchMock = Mockery::mock(VectorSearchService::class);
+    $service = makeRagServiceForHelperTests($embeddingMock, $vectorSearchMock);
+
+    $chunk = new DocumentChunk([
+        'content' => 'alpha beta gamma delta epsilon',
+        'excerpt' => 'alpha',
+    ]);
+
+    $truncated = $service->fitChunkToBudgetPublic($chunk, 5, 1);
+
+    expect($truncated)->not->toBeNull()
+        ->and($truncated->content)->toBe('alp…')
+        ->and($truncated->rag_truncated)->toBeTrue()
+        ->and($truncated->excerpt)->toBe('alpha');
+
+    $skipped = $service->fitChunkToBudgetPublic(new DocumentChunk(['content' => '   ']), 5, 5);
+
+    expect($skipped)->toBeNull();
+});
+
+test('queryWithStream marks low-confidence retrieval when similarity is below threshold', function () {
+    $embeddingMock = Mockery::mock(EmbeddingService::class);
+    $vectorSearchMock = Mockery::mock(VectorSearchService::class);
+    $service = makeRagServiceForHelperTests($embeddingMock, $vectorSearchMock);
+
+    setRagServiceDocuments($service, collect([
+        makeChunkForRagService(1, 11, 'Runbook', 'Deployment checklist exists.', 0, 0.42),
+    ]));
+
+    $response = $service->queryWithStream('What is our runbook?', 5);
+
+    expect($response['retrieval']['is_low_confidence'])->toBeTrue()
+        ->and($response['documents']->first()->rag_similarity)->toBe(0.42)
+        ->and($response['context'])->toContain('[S1]')
+        ->and($response['user_prompt'])->toContain('low confidence');
+});
+
+test('evaluateQuery returns quality tiers and context metrics', function () {
+    $embeddingMock = Mockery::mock(EmbeddingService::class);
+    $vectorSearchMock = Mockery::mock(VectorSearchService::class);
+    $service = makeRagServiceForHelperTests($embeddingMock, $vectorSearchMock);
+
+    setRagServiceDocuments($service, collect([
+        makeChunkForRagService(1, 12, 'Runbook', 'One', 0, 0.9),
+        makeChunkForRagService(2, 13, 'Runbook', 'Two', 1, 0.82),
+    ]));
+
+    $good = $service->evaluateQuery('Deployment questions');
+
+    expect($good['question_length'])->toBe(20)
+        ->and($good['documents_found'])->toBe(2)
+        ->and($good['has_sufficient_context'])->toBeTrue()
+        ->and($good['estimated_answer_quality'])->toBe('excellent')
+        ->and($good['top_similarity'])->toBe(0.9);
+
+    setRagServiceDocuments($service, collect());
+
+    $poor = $service->evaluateQuery('No docs yet');
+
+    expect($poor['documents_found'])->toBe(0)
+        ->and($poor['has_sufficient_context'])->toBeFalse()
+        ->and($poor['estimated_answer_quality'])->toBe('poor');
+});
+
+afterEach(function (): void {
+    Mockery::close();
+});

--- a/tests/Unit/VectorSearchServiceTest.php
+++ b/tests/Unit/VectorSearchServiceTest.php
@@ -1,0 +1,157 @@
+<?php
+
+use App\Models\Document;
+use App\Models\DocumentChunk;
+use App\Models\User;
+use App\Services\EmbeddingService;
+use App\Services\PgVectorPreflightService;
+use App\Services\VectorSearchService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+uses(RefreshDatabase::class);
+uses(TestCase::class);
+
+function makeVectorSearchService(EmbeddingService $embeddingService): VectorSearchService
+{
+    $preflight = new class extends PgVectorPreflightService
+    {
+        protected function currentDriver(): string
+        {
+            return 'sqlite';
+        }
+    };
+
+    return new VectorSearchService($embeddingService, $preflight);
+}
+
+test('findWithSimilarity returns null when document is missing or has no embedding', function () {
+    $embeddingService = Mockery::mock(EmbeddingService::class);
+    $service = makeVectorSearchService($embeddingService);
+
+    expect($service->findWithSimilarity(99, 'search'))->toBeNull();
+
+    $user = User::factory()->create();
+
+    $document = Document::create([
+        'user_id' => $user->id,
+        'title' => 'Unembedded',
+        'file_path' => 'documents/none.txt',
+        'file_type' => 'txt',
+        'content' => 'missing vector',
+        'excerpt' => 'missing vector',
+        'status' => 'completed',
+        'embedding' => null,
+    ]);
+
+    expect($service->findWithSimilarity($document->id, 'search'))->toBeNull();
+});
+
+test('findWithSimilarity returns computed cosine similarity for embedded documents', function () {
+    $embeddingService = Mockery::mock(EmbeddingService::class);
+    $embeddingService->shouldReceive('generateEmbedding')->once()->with('search')->andReturn([1.0, 0.0, 0.0]);
+    $embeddingService->shouldReceive('cosineSimilarity')->once()->with([0.8, 0.6, 0.0], [1.0, 0.0, 0.0])->andReturn(0.8);
+
+    $service = makeVectorSearchService($embeddingService);
+
+    $user = User::factory()->create();
+    $document = Document::create([
+        'user_id' => $user->id,
+        'title' => 'Embedded',
+        'file_path' => 'documents/embedded.txt',
+        'file_type' => 'txt',
+        'content' => 'has vector',
+        'excerpt' => 'has vector',
+        'status' => 'completed',
+        'embedding' => [0.8, 0.6, 0.0],
+    ]);
+
+    $result = $service->findWithSimilarity($document->id, 'search');
+
+    expect($result)->toBeArray()
+        ->and($result['document']->id)->toBe($document->id)
+        ->and($result['similarity'])->toBe(0.8);
+});
+
+test('calculateSimilarities returns chunks ordered by cosine similarity', function () {
+    $embeddingService = Mockery::mock(EmbeddingService::class);
+    $embeddingService->shouldReceive('generateEmbedding')->once()->with('search')->andReturn([1.0, 0.0, 0.0]);
+    $embeddingService->shouldReceive('cosineSimilarity')->times(2)->andReturn(0.95, 0.2);
+
+    $service = makeVectorSearchService($embeddingService);
+
+    $user = User::factory()->create();
+    $document = Document::create([
+        'user_id' => $user->id,
+        'title' => 'D1',
+        'file_path' => 'documents/d1.txt',
+        'file_type' => 'txt',
+        'content' => 'chunk one',
+        'excerpt' => 'chunk one',
+        'status' => 'completed',
+        'embedding' => [0.4, 0.9, 0.1],
+    ]);
+
+    DocumentChunk::create([
+        'document_id' => $document->id,
+        'user_id' => $user->id,
+        'chunk_index' => 0,
+        'content' => 'good chunk',
+        'excerpt' => 'good chunk',
+        'embedding' => [1.0, 0.0, 0.0],
+        'char_count' => 10,
+        'token_count' => 3,
+        'metadata' => [],
+    ]);
+
+    DocumentChunk::create([
+        'document_id' => $document->id,
+        'user_id' => $user->id,
+        'chunk_index' => 1,
+        'content' => 'other chunk',
+        'excerpt' => 'other chunk',
+        'embedding' => [0.0, 1.0, 0.0],
+        'char_count' => 11,
+        'token_count' => 3,
+        'metadata' => [],
+    ]);
+
+    $ordered = $service->calculateSimilarities('search');
+
+    expect($ordered->count())->toBe(2)
+        ->and($ordered->first()['similarity'])->toBe(0.95)
+        ->and($ordered->last()['similarity'])->toBe(0.2);
+});
+
+test('fromDocumentFallback builds pseudo chunk metadata', function () {
+    $embeddingService = Mockery::mock(EmbeddingService::class);
+    $service = makeVectorSearchService($embeddingService);
+
+    $user = User::factory()->create();
+    $document = Document::create([
+        'user_id' => $user->id,
+        'title' => 'Fallback',
+        'file_path' => 'documents/fallback.txt',
+        'file_type' => 'txt',
+        'content' => 'fallback body',
+        'excerpt' => 'fallback body',
+        'status' => 'completed',
+        'embedding' => [0.9, 0.1, 0.0],
+    ]);
+
+    $reflection = new ReflectionClass($service);
+    $method = $reflection->getMethod('fromDocumentFallback');
+    $method->setAccessible(true);
+
+    $chunk = $method->invoke($service, $document, 3);
+
+    expect($chunk->document_id)->toBe($document->id)
+        ->and($chunk->chunk_index)->toBe(3)
+        ->and($chunk->content)->toBe('fallback body')
+        ->and($chunk->metadata)->toBe(['source' => 'document_fallback'])
+        ->and($chunk->relationLoaded('document'))->toBeTrue();
+});
+
+afterEach(function (): void {
+    Mockery::close();
+});


### PR DESCRIPTION
## Summary
- Add unit coverage for `EmbeddingService` math/parsing paths (empty input, malformed payloads, vector mismatch, similarity math edge cases).
- Add targeted unit tests for `PgVectorPreflightService` non-PostgreSQL skip behavior.
- Add focused `RagService` helper-path tests for low-confidence prompt behavior, budget truncation behavior, stream payload metadata, and quality estimation.
- Extend chunking edge-case coverage for blank input, overlap clamping, and metadata propagation.

## Validation
- `php artisan test --compact --testsuite=Unit`
- `php artisan test --compact --testsuite=Feature`
- `vendor/bin/pint --dirty --format agent`
