### PR TITLE
fix: enforce https urls in production

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
 
@@ -35,6 +36,10 @@ class AppServiceProvider extends ServiceProvider
     protected function configureDefaults(): void
     {
         Date::use(CarbonImmutable::class);
+
+        if (app()->isProduction()) {
+            URL::forceScheme('https');
+        }
 
         DB::prohibitDestructiveCommands(
             app()->isProduction(),

--- a/tests/Unit/AppServiceProviderTest.php
+++ b/tests/Unit/AppServiceProviderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Providers\AppServiceProvider;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+test('forces HTTPS scheme in production', function () {
+    $originalEnvironment = app()->environment();
+    app()->instance('env', 'production');
+
+    (new AppServiceProvider(app()))->boot();
+
+    $urlGenerator = app('url');
+    $forceSchemeProperty = (new ReflectionClass($urlGenerator))->getProperty('forceScheme');
+    $forceSchemeProperty->setAccessible(true);
+
+    $forcedScheme = $forceSchemeProperty->getValue($urlGenerator);
+
+    expect($forcedScheme)->toBe('https://');
+
+    URL::forceScheme(null);
+    app()->instance('env', $originalEnvironment);
+});


### PR DESCRIPTION
## Summary
- Force URL generation to use HTTPS when APP_ENV is production via AppServiceProvider boot configuration.
- Add a regression test to verify production environment sets Laravel URL generator to forced HTTPS.

## Testing
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Unit/AppServiceProviderTest.php

## Context
This prevents mixed-content issues when deployments terminate TLS at a proxy/load balancer but Laravel still generates \`http\` links.