### PR TITLE
fix: reapply reverted issue-35 fixes via PR workflow

### DIFF
--- a/app/Livewire/DocumentUploader.php
+++ b/app/Livewire/DocumentUploader.php
@@ -59,7 +59,7 @@ class DocumentUploader extends Component
         }
     }
 
-    public function processUpload(): void
+    public function updatedUploads(): void
     {
         if ($this->isProcessing || empty($this->uploads)) {
             return;
@@ -76,9 +76,6 @@ class DocumentUploader extends Component
         $queued = 0;
         $failed = 0;
         $errors = [];
-
-        $totalUploads = count($this->uploads);
-
         try {
             while (! empty($this->uploads)) {
                 $queued++;
@@ -108,18 +105,22 @@ class DocumentUploader extends Component
                     ]);
 
                     ProcessDocumentIngestion::dispatch($document->id);
+                    $queued++;
                 } catch (\Throwable $e) {
                     $failed++;
                     $errors[] = $upload->getClientOriginalName().': '.$e->getMessage();
                 }
             }
 
-            $msg = "Upload finished. Queued: {$totalUploads}, failed: {$failed}.";
-            if ($errors !== []) {
-                $msg .= ' Errors: '.implode(' | ', $errors);
+            if ($isMultiFile) {
+                $msg = "Upload finished. Queued: {$queued}, failed: {$failed}.";
+                if ($errors !== []) {
+                    $msg .= ' Errors: '.implode(' | ', $errors);
+                }
+                $this->statusMessage = $msg;
+            } else {
+                $this->statusMessage = 'Upload accepted. Document is queued for processing.';
             }
-
-            $this->statusMessage = $msg;
 
             $this->upload = null;
             $this->uploads = [];

--- a/app/Livewire/DocumentUploader.php
+++ b/app/Livewire/DocumentUploader.php
@@ -61,6 +61,11 @@ class DocumentUploader extends Component
 
     public function updatedUploads(): void
     {
+        $this->processUpload();
+    }
+
+    public function processUpload(): void
+    {
         if ($this->isProcessing || empty($this->uploads)) {
             return;
         }
@@ -73,12 +78,16 @@ class DocumentUploader extends Component
         $this->isProcessing = true;
         $this->statusMessage = 'Parsing document(s)...';
 
+        $totalUploads = count($this->uploads);
+        $isMultiFile = $totalUploads > 1;
+        $processed = 0;
         $queued = 0;
         $failed = 0;
         $errors = [];
+
         try {
             while (! empty($this->uploads)) {
-                $queued++;
+                $processed++;
 
                 /** @var object $upload */
                 $upload = array_shift($this->uploads);
@@ -86,7 +95,7 @@ class DocumentUploader extends Component
                 $this->statusMessage = sprintf(
                     'Parsing file %s (%d of %d)...',
                     $upload->getClientOriginalName(),
-                    $queued,
+                    $processed,
                     $totalUploads
                 );
 
@@ -112,16 +121,12 @@ class DocumentUploader extends Component
                 }
             }
 
-            if ($isMultiFile) {
-                $msg = "Upload finished. Queued: {$queued}, failed: {$failed}.";
-                if ($errors !== []) {
-                    $msg .= ' Errors: '.implode(' | ', $errors);
-                }
-                $this->statusMessage = $msg;
-            } else {
-                $this->statusMessage = 'Upload accepted. Document is queued for processing.';
+            $message = "Upload finished. Queued: {$queued}, failed: {$failed}.";
+            if ($errors !== [] && $isMultiFile) {
+                $message .= ' Errors: '.implode(' | ', $errors);
             }
 
+            $this->statusMessage = $message;
             $this->upload = null;
             $this->uploads = [];
             $this->loadDocuments();

--- a/app/Services/DocumentParserService.php
+++ b/app/Services/DocumentParserService.php
@@ -22,18 +22,28 @@ class DocumentParserService
     public function parse(UploadedFile $file): array
     {
         $fileType = strtolower($file->getClientOriginalExtension());
-        $filePath = $file->getRealPath();
         $originalName = $file->getClientOriginalName();
 
-        $content = match ($fileType) {
-            'pdf' => $this->parsePdf($filePath),
-            'txt' => $this->parseTxt($filePath),
-            'md', 'markdown' => $this->parseMarkdown($filePath),
-            default => throw new \InvalidArgumentException("Unsupported file type: {$fileType}"),
-        };
+        // Read content via get() which works for both local and S3-stored temp files
+        $rawContent = $file->get();
+
+        // Write to local temp file for parsers that need file path
+        $tempFile = tempnam(sys_get_temp_dir(), 'rag_');
+        file_put_contents($tempFile, $rawContent);
+
+        try {
+            $content = match ($fileType) {
+                'pdf' => $this->parsePdf($tempFile),
+                'txt' => $this->parseTxt($tempFile),
+                'md', 'markdown' => $this->parseMarkdown($tempFile),
+                default => throw new \InvalidArgumentException("Unsupported file type: {$fileType}"),
+            };
+        } finally {
+            @unlink($tempFile);
+        }
 
         $excerpt = $this->generateExcerpt($content);
-        $storagePath = $this->storeFile($file);
+        $storagePath = $this->storeFile($file, $rawContent);
 
         return [
             'title' => pathinfo($originalName, PATHINFO_FILENAME),
@@ -117,7 +127,7 @@ class DocumentParserService
     /**
      * Store uploaded file to disk
      */
-    protected function storeFile(UploadedFile $file): string
+    protected function storeFile(UploadedFile $file, string $content): string
     {
         $disk = config('services.document.disk', 'local');
         $path = config('services.document.storage_path', 'documents');
@@ -125,7 +135,7 @@ class DocumentParserService
         $filename = Str::uuid().'.'.$file->getClientOriginalExtension();
         $fullPath = $path.'/'.$filename;
 
-        Storage::disk($disk)->put($fullPath, file_get_contents($file->getRealPath()));
+        Storage::disk($disk)->put($fullPath, $content);
 
         return $fullPath;
     }

--- a/resources/views/livewire/document-uploader.blade.php
+++ b/resources/views/livewire/document-uploader.blade.php
@@ -13,8 +13,9 @@
                     accept=".pdf,.txt,.md,.markdown"
                     :disabled="$isProcessing"
                 />
-                <flux:error name="upload" />
-                @error('upload')
+                <flux:error name="uploads" />
+                <flux:error name="uploads.*" />
+                @error('uploads.*')
                     <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                 @enderror
             </flux:field>

--- a/resources/views/livewire/rag-chat.blade.php
+++ b/resources/views/livewire/rag-chat.blade.php
@@ -81,7 +81,7 @@
     <div class="border-t border-neutral-200 dark:border-neutral-700 p-4">
         <form wire:submit.prevent="sendQuery" class="flex gap-3">
             <flux:input
-                wire:model.live="query"
+                wire:model.live.debounce.250ms="query"
                 placeholder="Ask a question about your documents..."
                 :disabled="$isProcessing"
                 class="flex-1"
@@ -89,7 +89,7 @@
             <flux:button
                 type="submit"
                 variant="primary"
-                :disabled="$isProcessing || $query === ''"
+                :disabled="$isProcessing || blank(trim($query))"
                 icon="paper-airplane"
             >
                 Send

--- a/tests/Feature/DocumentIngestionPipelineTest.php
+++ b/tests/Feature/DocumentIngestionPipelineTest.php
@@ -44,8 +44,7 @@ test('upload request dispatches async ingestion job and returns quickly', functi
     $this->app->instance(DocumentParserService::class, $parserMock);
 
     Livewire::test(DocumentUploader::class)
-        ->set('upload', $uploadedFile)
-        ->call('processUpload')
+        ->set('uploads', [$uploadedFile])
         ->assertSet('isProcessing', false)
         ->assertSet('statusMessage', 'Upload finished. Queued: 1, failed: 0.');
 


### PR DESCRIPTION
## Summary
- Reapply the two reverted fixes using the required branch/PR workflow.
- Restore S3 temp upload handling by using `$file->get()` instead of `getRealPath()`.
- Restore multi-upload, RAG chat submit behavior, and queue default routing adjustments.

## Context
These changes were previously committed directly to `main` and reverted (`959f9bd`, `53368b1`) due to workflow violation. This PR reapplies the same code changes on a feature branch for proper review and merge.

## Commits in this PR
- `32faed5` fix: use `$file->get()` instead of `getRealPath()` for S3 temp uploads
- `933eacd` fix: multi-upload, RAG chat submit, and queue default routing

## Validation
Unable to run project test/lint commands in this execution environment because `php` and `composer` are not installed (`command not found`).
Please run CI / local Laravel checks in review environment.
